### PR TITLE
Fix setting GID map on newer kernel, post CVE-2014-8989

### DIFF
--- a/map.c
+++ b/map.c
@@ -197,6 +197,8 @@ void writemap(pid_t pid, int type, char *map) {
   while ((map = mapitem(map, &first, &lower, &count)))
     append(&text, "%u %u %u\n", first, lower, count);
 
+  if (type == GID)
+    procsetgroups(pid, "deny");
   path = string("/proc/%d/%s", pid, idfile(type));
   if ((fd = open(path, O_WRONLY)) < 0)
     error(1, 0, "Failed to set container %s map", idname(type));

--- a/util.c
+++ b/util.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include "contain.h"
@@ -68,4 +70,18 @@ void waitforstop(pid_t child) {
     error(1, errno, "waitpid");
   if (!WIFSTOPPED(status))
     exit(WEXITSTATUS(status));
+}
+
+void procsetgroups(pid_t parent, const char *action) {
+  char *path;
+  int fd;
+
+  path = string("/proc/%d/setgroups", parent);
+  if ((fd = open(path, O_WRONLY)) < 0)
+    error(0, 0, "Unable to open container setgroups file");
+  else if (write(fd, action, strlen(action)) != (ssize_t) strlen(action))
+    error(1, 0, "Failed to write container setgroups");
+  if (fd)
+    close(fd);
+  free(path);
 }


### PR DESCRIPTION
To address the named CVE, there was a patch serie merged into all
maintained kernels (3.17.4+). Specifically, the patch entitled
"userns: Allow setting gid_maps without privilege when setgroups is
disabled" causes to both pseudo and contain to be unable to set GID
map.

This patch fixes the GID problem by writing "deny" into the
/proc/PID/setgroups file prior to setting the GID map.

Signed-off-by: Alin Dobre <alin.dobre@outlook.com>