### PR TITLE
use more portable err.h instead of error.h

### DIFF
--- a/contain.c
+++ b/contain.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <errno.h>
-#include <error.h>
+#include <err.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <sched.h>
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
   parent = getpid();
   switch (child = fork()) {
     case -1:
-      error(1, errno, "fork");
+      err(1, "fork");
     case 0:
       raise(SIGSTOP);
       if (geteuid() != 0)
@@ -75,36 +75,36 @@ int main(int argc, char **argv) {
 
       if (outside) {
         if (setgid(getgid()) < 0 || setuid(getuid()) < 0)
-          error(1, 0, "Failed to drop privileges");
+          errx(1, "Failed to drop privileges");
         execlp(SHELL, SHELL, "-c", outside, NULL);
-        error(1, errno, "exec %s", outside);
+        err(1, "exec %s", outside);
       }
 
       exit(EXIT_SUCCESS);
   }
 
   if (setgid(getgid()) < 0 || setuid(getuid()) < 0)
-    error(1, 0, "Failed to drop privileges");
+    errx(1, "Failed to drop privileges");
 
   if (unshare(CLONE_NEWUSER) < 0)
-    error(1, 0, "Failed to unshare user namespace");
+    errx(1, "Failed to unshare user namespace");
 
 #ifdef CLONE_NEWCGROUP
   if (unshare(CLONE_NEWCGROUP) < 0)
-    error(1, 0, "Failed to unshare cgroup namespace");
+    errx(1, "Failed to unshare cgroup namespace");
 #endif
 
   if (unshare(CLONE_NEWIPC) < 0)
-    error(1, 0, "Failed to unshare IPC namespace");
+    errx(1, "Failed to unshare IPC namespace");
 
   if (!hostnet && unshare(CLONE_NEWNET) < 0)
-    error(1, 0, "Failed to unshare network namespace");
+    errx(1, "Failed to unshare network namespace");
 
   if (unshare(CLONE_NEWNS) < 0)
-    error(1, 0, "Failed to unshare mount namespace");
+    errx(1, "Failed to unshare mount namespace");
 
   if (unshare(CLONE_NEWUTS) < 0)
-    error(1, 0, "Failed to unshare UTS namespace");
+    errx(1, "Failed to unshare UTS namespace");
 
   waitforstop(child);
   kill(child, SIGCONT);
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
   unshare(CLONE_NEWPID);
   switch (child = fork()) {
     case -1:
-      error(1, errno, "fork");
+      err(1, "fork");
     case 0:
       mountproc();
       if (!hostnet)
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
         execv(argv[optind + 1], argv + optind + 1);
       else
         execl(SHELL, SHELL, NULL);
-      error(1, errno, "exec");
+      err(1, "exec");
   }
 
   return supervise(child, master);

--- a/inject.c
+++ b/inject.c
@@ -1,7 +1,7 @@
 #define _GNU_SOURCE
 #include <dirent.h>
 #include <errno.h>
-#include <error.h>
+#include <err.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <sched.h>
@@ -49,12 +49,12 @@ void join(pid_t pid, char *type) {
 
   if ((fd = open(path, O_RDONLY)) >= 0) {
     if (syscall(__NR_setns, fd, 0) < 0 && strcmp(type, "user") == 0)
-      error(1, 0, "Failed to join user namespace");
+      errx(1, "Failed to join user namespace");
     close(fd);
   } else if (errno != ENOENT) {
-    error(1, 0, "PID %u does not belong to you", pid);
+    errx(1, "PID %u does not belong to you", pid);
   } else if (strcmp(type, "user") == 0) {
-    error(1, 0, "PID %u not found or user namespace unavailable", pid);
+    errx(1, "PID %u not found or user namespace unavailable", pid);
   }
 
   free(path);
@@ -81,9 +81,9 @@ int main(int argc, char **argv) {
     usage(argv[0]);
 
   if (geteuid() != getuid())
-    error(1, 0, "setuid installation is unsafe");
+    errx(1, "setuid installation is unsafe");
   else if (getegid() != getgid())
-    error(1, 0, "setgid installation is unsafe");
+    errx(1, "setgid installation is unsafe");
 
   join(parent, "user");
   setgid(0);
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
   setuid(0);
 
   if (!(dir = opendir("/proc")))
-    error(1, 0, "Failed to list processes");
+    errx(1, "Failed to list processes");
   while (child < 0 && (entry = readdir(dir))) {
     pid = strtol(entry->d_name, &end, 10);
     if (end == entry->d_name || *end)
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     free(item);
 
   if (child < 0)
-    error(1, 0, "PID %u is not a container supervisor", parent);
+    errx(1, "PID %u is not a container supervisor", parent);
 
   join(child, "cgroup");
   join(child, "ipc");
@@ -122,11 +122,11 @@ int main(int argc, char **argv) {
   join(child, "mnt");
 
   if (chdir("/") < 0)
-    error(1, 0, "Failed to enter container root directory");
+    errx(1, "Failed to enter container root directory");
 
   switch (child = fork()) {
     case -1:
-      error(1, errno, "fork");
+      err(1, "fork");
     case 0:
       if (argv[2])
         execvp(argv[2], argv + 2);
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
         execl(getenv("SHELL"), getenv("SHELL"), NULL);
       else
         execl(SHELL, SHELL, NULL);
-      error(1, errno, "exec");
+      err(1, "exec");
   }
 
   waitforexit(child);

--- a/map.c
+++ b/map.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <errno.h>
-#include <error.h>
+#include <err.h>
 #include <grp.h>
 #include <fcntl.h>
 #include <pwd.h>
@@ -17,9 +17,9 @@ void denysetgroups(pid_t pid) {
 
   path = string("/proc/%d/setgroups", pid);
   if ((fd = open(path, O_WRONLY)) < 0)
-    error(1, 0, "Failed to disable setgroups() in container");
+    errx(1, "Failed to disable setgroups() in container");
   else if (write(fd, text, strlen(text)) != (ssize_t) strlen(text))
-    error(1, 0, "Failed to disable setgroups() in container");
+    errx(1, "Failed to disable setgroups() in container");
   close(fd);
   free(path);
 }
@@ -35,16 +35,16 @@ static char *getmap(pid_t pid, int type) {
   else
     path = string("/proc/%d/%s", pid, idfile(type));
   if (!(file = fopen(path, "r")))
-    error(1, 0, "Cannot read %s", path);
+    errx(1, "Cannot read %s", path);
 
   while (getline(&line, &size, file) >= 0) {
     if (sscanf(line, " %u %u %u", &first, &lower, &count) != 3)
-      error(1, 0, "Invalid map data in %s", path);
+      errx(1, "Invalid map data in %s", path);
     append(&result, "%s%u:%u:%u", result ? "," : "", first, lower, count);
   }
 
   if (!result)
-    error(1, 0, "Invalid map data in %s", path);
+    errx(1, "Invalid map data in %s", path);
 
   fclose(file);
   free(line);
@@ -61,7 +61,7 @@ static char *mapitem(char *map, unsigned *first, unsigned *lower,
   if (map == NULL || *map == '\0')
     return NULL;
   if (sscanf(map, "%u:%u:%u%zn", first, lower, count, &skip) < 3)
-    error(1, 0, "Invalid ID map '%s'", map);
+    errx(1, "Invalid ID map '%s'", map);
   return map + skip;
 }
 
@@ -73,7 +73,7 @@ static char *rangeitem(char *range, unsigned *start, unsigned *length) {
   if (range == NULL || *range == '\0')
     return NULL;
   if (sscanf(range, "%u:%u%zn", start, length, &skip) < 2)
-    error(1, 0, "Invalid ID range '%s'", range);
+    errx(1, "Invalid ID range '%s'", range);
   return range + skip;
 }
 
@@ -93,7 +93,7 @@ static char *readranges(int type) {
   user = user ? user : getlogin();
   if (!user || !(passwd = getpwnam(user)) || passwd->pw_uid != getuid()) {
     if (!(passwd = getpwuid(getuid())))
-      error(1, 0, "Failed to validate your username");
+      errx(1, "Failed to validate your username");
     user = passwd->pw_name;
   }
   endpwent();
@@ -126,7 +126,7 @@ static char *rootdefault(int type) {
   while ((cursor = mapitem(cursor, &first, &lower, &count))) {
     if (first == 0) {
       if (count == 1 && first >= last)
-        error(1, 0, "No unprivileged %s available\n", idname(type));
+        errx(1, "No unprivileged %s available\n", idname(type));
       first++, lower++, count--;
     }
 
@@ -184,7 +184,7 @@ static void validate(char *range, unsigned first, unsigned count) {
         validate(range, start + length, first + count - start - length);
       return;
     }
-  error(1, 0, "Cannot map onto IDs that are not delegated to you");
+  errx(1, "Cannot map onto IDs that are not delegated to you");
 }
 
 static void verifymap(char *map, char *range) {
@@ -212,9 +212,9 @@ void writemap(pid_t pid, int type, char *map) {
 
   path = string("/proc/%d/%s", pid, idfile(type));
   if ((fd = open(path, O_WRONLY)) < 0)
-    error(1, 0, "Failed to set container %s map", idname(type));
+    errx(1, "Failed to set container %s map", idname(type));
   else if (write(fd, text, strlen(text)) != (ssize_t) strlen(text))
-    error(1, 0, "Failed to set container %s map", idname(type));
+    errx(1, "Failed to set container %s map", idname(type));
 
   close(fd);
   free(path);

--- a/mount.c
+++ b/mount.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <errno.h>
-#include <error.h>
+#include <err.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -18,7 +18,7 @@ static void bindnode(char *src, char *dst) {
   if ((fd = open(dst, O_WRONLY | O_CREAT, 0600)) >= 0)
     close(fd);
   if (mount(src, dst, NULL, MS_BIND, NULL) < 0)
-    error(1, 0, "Failed to bind %s into new /dev filesystem", src);
+    errx(1, "Failed to bind %s into new /dev filesystem", src);
 }
 
 void cleanup(void) {
@@ -36,18 +36,18 @@ void createroot(char *src, int console, char *helper) {
   atexit(cleanup);
 
   if (mount(src, root, NULL, MS_BIND | MS_REC, NULL) < 0)
-    error(1, 0, "Failed to bind new root filesystem");
+    errx(1, "Failed to bind new root filesystem");
   else if (chdir(root) < 0)
-    error(1, 0, "Failed to enter new root filesystem");
+    errx(1, "Failed to enter new root filesystem");
 
   mask = umask(0);
   mkdir("dev" , 0755);
   if (mount("tmpfs", "dev", "tmpfs", 0, "mode=0755") < 0)
-    error(1, 0, "Failed to mount /dev tmpfs in new root filesystem");
+    errx(1, "Failed to mount /dev tmpfs in new root filesystem");
 
   mkdir("dev/pts", 0755);
   if (mount("devpts", "dev/pts", "devpts", 0, "newinstance,ptmxmode=666") < 0)
-    error(1, 0, "Failed to mount /dev/pts in new root filesystem");
+    errx(1, "Failed to mount /dev/pts in new root filesystem");
 
   mkdir("dev/tmp", 0755);
   umask(mask);
@@ -65,10 +65,10 @@ void createroot(char *src, int console, char *helper) {
   if (helper)
     switch (child = fork()) {
       case -1:
-        error(1, errno, "fork");
+        err(1, "fork");
       case 0:
         execlp(SHELL, SHELL, "-c", helper, NULL);
-        error(1, errno, "exec %s", helper);
+        err(1, "exec %s", helper);
       default:
         waitforexit(child);
     }
@@ -76,7 +76,7 @@ void createroot(char *src, int console, char *helper) {
 
 void enterroot(void) {
   if (syscall(__NR_pivot_root, ".", "dev/tmp") < 0)
-    error(1, 0, "Failed to pivot into new root filesystem");
+    errx(1, "Failed to pivot into new root filesystem");
 
   if (chdir("/dev/tmp") >= 0) {
     while (*root == '/')
@@ -87,7 +87,7 @@ void enterroot(void) {
   root = NULL;
 
   if (chdir("/") < 0 || umount2("/dev/tmp", MNT_DETACH) < 0)
-    error(1, 0, "Failed to detach old root filesystem");
+    errx(1, "Failed to detach old root filesystem");
   else
     rmdir("/dev/tmp");
 }
@@ -100,7 +100,7 @@ void mountproc(void) {
   umask(mask);
 
   if (mount("proc", "proc", "proc", 0, NULL) < 0)
-    error(1, 0, "Failed to mount /proc in new root filesystem");
+    errx(1, "Failed to mount /proc in new root filesystem");
 }
 
 void mountsys(void) {
@@ -111,6 +111,6 @@ void mountsys(void) {
   umask(mask);
 
   if (mount("sysfs", "sys", "sysfs", 0, NULL) < 0)
-    error(1, 0, "Failed to mount /sys in new root filesystem");
+    errx(1, "Failed to mount /sys in new root filesystem");
   mount("cgroup2", "sys/fs/cgroup", "cgroup2", 0, NULL);
 }

--- a/pseudo.c
+++ b/pseudo.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <errno.h>
-#include <error.h>
+#include <err.h>
 #include <grp.h>
 #include <sched.h>
 #include <signal.h>
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
   parent = getpid();
   switch (child = fork()) {
     case -1:
-      error(1, errno, "fork");
+      err(1, "fork");
     case 0:
       raise(SIGSTOP);
       if (geteuid() != 0)
@@ -52,10 +52,10 @@ int main(int argc, char **argv) {
   }
 
   if (setgid(getgid()) < 0 || setuid(getuid()) < 0)
-    error(1, 0, "Failed to drop privileges");
+    errx(1, "Failed to drop privileges");
 
   if (unshare(CLONE_NEWUSER) < 0)
-    error(1, errno, "Failed to unshare user namespace");
+    err(1, "Failed to unshare user namespace");
 
   waitforstop(child);
   kill(child, SIGCONT);
@@ -72,6 +72,6 @@ int main(int argc, char **argv) {
   else
     execl(SHELL, SHELL, NULL);
 
-  error(1, errno, "exec");
+  err(1, "exec");
   return EXIT_FAILURE;
 }

--- a/util.c
+++ b/util.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <errno.h>
-#include <error.h>
+#include <err.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,7 +15,7 @@ char *append(char **destination, const char *format, ...) {
 
   va_start(args, format);
   if (vasprintf(&extra, format, args) < 0)
-    error(1, errno, "asprintf");
+    err(1, "asprintf");
   va_end(args);
 
   if (*destination == NULL) {
@@ -24,7 +24,7 @@ char *append(char **destination, const char *format, ...) {
   }
 
   if (asprintf(&result, "%s%s", *destination, extra) < 0)
-      error(1, errno, "asprintf");
+      err(1, "asprintf");
   free(*destination);
   free(extra);
   *destination = result;
@@ -37,7 +37,7 @@ char *string(const char *format, ...) {
 
   va_start(args, format);
   if (vasprintf(&result, format, args) < 0)
-    error(1, errno, "asprintf");
+    err(1, "asprintf");
   va_end(args);
   return result;
 }
@@ -46,9 +46,9 @@ char *tmpdir(void) {
   char *dir;
 
   if (!(dir = strdup("/tmp/XXXXXX")))
-    error(1, errno, "strdup");
+    err(1, "strdup");
   else if (!mkdtemp(dir))
-    error(1, 0, "Failed to create temporary directory");
+    errx(1, "Failed to create temporary directory");
   return dir;
 }
 
@@ -56,7 +56,7 @@ void waitforexit(pid_t child) {
   int status;
 
   if (waitpid(child, &status, 0) < 0)
-    error(1, errno, "waitpid");
+    err(1, "waitpid");
   else if (WEXITSTATUS(status) != EXIT_SUCCESS)
     exit(WEXITSTATUS(status));
 }
@@ -65,7 +65,7 @@ void waitforstop(pid_t child) {
   int status;
 
   if (waitpid(child, &status, WUNTRACED) < 0)
-    error(1, errno, "waitpid");
+    err(1, "waitpid");
   if (!WIFSTOPPED(status))
     exit(WEXITSTATUS(status));
 }


### PR DESCRIPTION
Hi, 
this patch allows `containers` to be build with musl libc, `error.h` is glibc specific.
`err` prints the message with `strerror(errno)` and `errx` without.